### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -36,7 +36,13 @@ router.get('/cats', limiter, function(request, response, next){
 router.get("/*", limiter, function (req, res, next){
     console.log("Here is a console log");
     var file = req.params[0] || 'views/index.html';
-    res.sendFile(path.join(__dirname, '../public', file));
+    var publicDir = path.join(__dirname, '../public');
+    var resolvedPath = path.resolve(publicDir, file);
+    if (!resolvedPath.startsWith(publicDir)) {
+        res.status(403).send('Access denied');
+        return;
+    }
+    res.sendFile(resolvedPath);
     //next();
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/gundter/walking_skeleton_homework/security/code-scanning/2](https://github.com/gundter/walking_skeleton_homework/security/code-scanning/2)

To fix the issue, we need to validate the user-provided `file` path to ensure it does not allow access to files outside the intended directory (`../public`). The best approach is to resolve the full path using `path.resolve` and then verify that the resolved path starts with the intended root directory. If the resolved path does not start with the root directory, we should reject the request with an appropriate HTTP status code (e.g., 403 Forbidden).

Steps to implement the fix:
1. Use `path.resolve` to normalize the `file` path and resolve any `..` segments.
2. Check if the resolved path starts with the intended root directory (`path.join(__dirname, '../public')`).
3. If the check fails, return a 403 Forbidden response.
4. If the check passes, proceed to send the file using `res.sendFile`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
