### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/gundter/walking_skeleton_homework/security/code-scanning/5](https://github.com/gundter/walking_skeleton_homework/security/code-scanning/5)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. For this Node.js CI workflow, the `contents: read` permission is sufficient, as it only needs to read the repository contents to install dependencies and run tests. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
